### PR TITLE
Add top margin and wider side margin to iOS bottom sheet header

### DIFF
--- a/src/Plugin.Maui.Spine/Presentation/HeaderBarConstants.cs
+++ b/src/Plugin.Maui.Spine/Presentation/HeaderBarConstants.cs
@@ -27,6 +27,7 @@ internal static class HeaderBarConstants
 
     public const double RegionSideMargin = 4;
     public const double SheetSideMargin = 10;
+    public const double SheetTopPadding = 0;
 
 #else
 
@@ -42,8 +43,14 @@ internal static class HeaderBarConstants
     public const double RegionButtonPadding = 0;
 
     public const double RegionSideMargin = 0;
-    public const double SheetSideMargin = 14;
+    public const double SheetSideMargin = 16;
 
+#if IOS || MACCATALYST
+    // Space below the UISheetPresentationController grabber handle
+    public const double SheetTopPadding = 20;
+#else
+    public const double SheetTopPadding = 0;
+#endif
 
 #endif
 

--- a/src/Plugin.Maui.Spine/Presentation/NavigationRegion.cs
+++ b/src/Plugin.Maui.Spine/Presentation/NavigationRegion.cs
@@ -7,7 +7,7 @@ namespace Plugin.Maui.Spine.Presentation;
 /// <summary>
 /// A <see cref="ContentView"/> that hosts a navigation stack and renders the Spine header bar.
 /// Supports interactive back-swipe gestures on mobile.
-/// Created and managed by Spine's DI infrastructure — you do not need to instantiate this directly.
+/// Created and managed by Spine's DI infrastructure ï¿½ you do not need to instantiate this directly.
 /// Reference it via <see cref="SpineHostPage.RootNavigationRegion"/> or
 /// <see cref="SpineHostPage.SheetNavigationRegion"/> when you need to inspect the current state.
 /// </summary>
@@ -119,7 +119,12 @@ public sealed class NavigationRegion : ContentView
     {
         var insets = _insetsProvider.SystemBarInsets;
         _container.Margin = new Thickness(0, -insets.Top, 0, 0);
-        _frameActionView.Margin = new Thickness(0, insets.Top, 0, 0);
+
+        var topMargin = insets.Top;
+        if (ViewModel.Presentation == NavigationPresentation.Sheet)
+            topMargin += HeaderBarConstants.SheetTopPadding;
+
+        _frameActionView.Margin = new Thickness(0, topMargin, 0, 0);
     }
 
     private void OnSystemInsetsChanged()


### PR DESCRIPTION
# Summary
- Adds `SheetTopPadding = 20` for iOS/MacCatalyst — space between the
  UISheetPresentationController grabber handle and the header row,
  matching native iOS sheet behaviour.
- `UpdateContainerMargin()` now adds `SheetTopPadding` to the header
  bar's top margin when `Presentation == Sheet`.
- Bumps `SheetSideMargin` 14 → 16 on non-Android platforms.
- All other platforms unaffected (Android and Windows get `SheetTopPadding = 0`).