### PR TITLE
Fix iOS bottom sheet dark mode - card background always white

### DIFF
--- a/src/Plugin.Maui.Spine/Presentation/BottomSheetPageExtensions.Apple.cs
+++ b/src/Plugin.Maui.Spine/Presentation/BottomSheetPageExtensions.Apple.cs
@@ -77,6 +77,16 @@ internal static class BottomSheetPageExtensions
         // Block interactive swipe-to-dismiss; every attempt goes through the delegate.
         sheetVc.ModalInPresentation = true;
 
+        // UISheetPresentationController's card surface does not reliably inherit the
+        // trait collection from the MAUI window. Explicitly mirror the MAUI app theme
+        // so the native sheet background renders dark when the app is in dark mode.
+        var isDark = Application.Current?.RequestedTheme == AppTheme.Dark
+            || (Application.Current?.RequestedTheme != AppTheme.Light
+                && Application.Current?.PlatformAppTheme == AppTheme.Dark);
+        sheetVc.OverrideUserInterfaceStyle = isDark
+            ? UIUserInterfaceStyle.Dark
+            : UIUserInterfaceStyle.Light;
+
         // ── Detents ──────────────────────────────────────────────────────────────
         var allowedDetents = bottomSheetBuilder.AllowedDetents.Count > 0
             ? bottomSheetBuilder.AllowedDetents
@@ -267,6 +277,8 @@ internal static class BottomSheetPageExtensions
         {
             base.ViewDidLoad();
 
+            View!.BackgroundColor = UIColor.Clear;
+
             _nativeContent.TranslatesAutoresizingMaskIntoConstraints = false;
             View!.AddSubview(_nativeContent);
 
@@ -276,6 +288,17 @@ internal static class BottomSheetPageExtensions
                 _nativeContent.TopAnchor.ConstraintEqualTo(View.TopAnchor),
                 _nativeContent.BottomAnchor.ConstraintEqualTo(View.BottomAnchor),
             ]);
+        }
+
+        public override void ViewWillAppear(bool animated)
+        {
+            base.ViewWillAppear(animated);
+
+            // The UISheetPresentationController card chrome lives in the presentation
+            // container view, not in this VC's view subtree. OverrideUserInterfaceStyle
+            // on the VC alone doesn't reach it — we must set it on the container too.
+            if (PresentationController?.ContainerView is { } container)
+                container.OverrideUserInterfaceStyle = OverrideUserInterfaceStyle;
         }
 
         public override void ViewDidDisappear(bool animated)

--- a/src/Plugin.Maui.Spine/Presentation/HeaderBar.cs
+++ b/src/Plugin.Maui.Spine/Presentation/HeaderBar.cs
@@ -230,8 +230,8 @@ internal class HeaderBar : Microsoft.Maui.Controls.ContentView
             ? new Thickness(HeaderBarConstants.SheetButtonPadding)
             : new Thickness(HeaderBarConstants.RegionButtonPadding);
 
-        //Test
-        _primaryPageActionView.Margin = new Thickness(HeaderBarConstants.SheetButtonPadding, 0, -HeaderBarConstants.SheetButtonPadding, 0);
+        var actionTopMargin = Presentation is NavigationPresentation.Sheet ? HeaderBarConstants.SheetTopPadding : 0;
+        _primaryPageActionView.Margin = new Thickness(HeaderBarConstants.SheetButtonPadding, actionTopMargin, -HeaderBarConstants.SheetButtonPadding, 0);
 
         _secondaryPageActionView.HeightRequest = HeaderBarConstants.Height;
 
@@ -239,7 +239,7 @@ internal class HeaderBar : Microsoft.Maui.Controls.ContentView
             ? new Thickness(HeaderBarConstants.SheetButtonPadding)
             : new Thickness(HeaderBarConstants.RegionButtonPadding);
 
-        _secondaryPageActionView.Margin = new Thickness(HeaderBarConstants.SheetButtonPadding, 0, -HeaderBarConstants.SheetButtonPadding, 0);
+        _secondaryPageActionView.Margin = new Thickness(HeaderBarConstants.SheetButtonPadding, actionTopMargin, -HeaderBarConstants.SheetButtonPadding, 0);
 
 
         UpdateSecondaryActionVisibility();

--- a/src/Plugin.Maui.Spine/Presentation/NavigationRegion.cs
+++ b/src/Plugin.Maui.Spine/Presentation/NavigationRegion.cs
@@ -120,11 +120,7 @@ public sealed class NavigationRegion : ContentView
         var insets = _insetsProvider.SystemBarInsets;
         _container.Margin = new Thickness(0, -insets.Top, 0, 0);
 
-        var topMargin = insets.Top;
-        if (ViewModel.Presentation == NavigationPresentation.Sheet)
-            topMargin += HeaderBarConstants.SheetTopPadding;
-
-        _frameActionView.Margin = new Thickness(0, topMargin, 0, 0);
+        _frameActionView.Margin = new Thickness(0, insets.Top, 0, 0);
     }
 
     private void OnSystemInsetsChanged()


### PR DESCRIPTION
## Summary

- `UISheetPresentationController`’s card chrome lives in the **presentation container view** — a separate UIKit-managed view hierarchy that does not inherit `OverrideUserInterfaceStyle` from the presented VC
- Mirror the MAUI app theme (via `RequestedTheme`/`PlatformAppTheme`) onto the sheet VC, then propagate it to `PresentationController.ContainerView` in `ViewWillAppear` (the earliest point the container is available)
- Clear the VC view background (`UIColor.Clear`) so the now-correctly-themed card surface shows through
- Also carries forward the pending header bar top-margin fix so sheet action buttons align correctly

## Test plan

- [ ] Open any bottom sheet in dark mode — card background should be dark, not white
- [ ] Open any bottom sheet in light mode — card background should remain white
- [ ] Toggle app theme at runtime and confirm new sheets open with the correct background
- [ ] Verify header bar action buttons still align correctly on sheet presentation

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)