### PR TITLE
Add /spine-issue skill and Claude issue workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "permissions": {
-    "allow": []
+    "allow": [
+      "Bash(gh issue view * --repo jonatansoderberg/Maui.Spine *)",
+      "Bash(gh issue list --repo jonatansoderberg/Maui.Spine *)",
+      "Bash(git branch --list *)",
+      "Bash(git checkout -b issue/*)",
+      "Bash(git checkout issue/*)",
+      "Bash(git log --oneline *)",
+      "Bash(mkdir -p issues)",
+      "Skill(spine-issue)",
+      "Skill(spine-issue:*)"
+    ]
   }
 }

--- a/.claude/skills/spine-issue.md
+++ b/.claude/skills/spine-issue.md
@@ -1,0 +1,143 @@
+---
+name: spine-issue
+description: Start working on a Maui.Spine GitHub issue. Fetches issue details, creates a branch, and sets up the issues changelog file with a documented plan. Invoke as /spine-issue <issue-id>.
+---
+
+You are starting work on a GitHub issue in the Maui.Spine repository (https://github.com/jonatansoderberg/Maui.Spine).
+
+The user invoked `/spine-issue` with an issue number. Extract it from `$ARGUMENTS` — it is the first (and only) token, e.g. `123`.
+
+Follow these steps **in order**. Do not skip any step. Do not write code yet.
+
+---
+
+## Step 1 — Fetch the issue
+
+Run:
+```
+gh issue view <id> --repo jonatansoderberg/Maui.Spine --json number,title,body,labels,assignees,state
+```
+
+Parse the JSON output to extract:
+- `number` — issue ID
+- `title` — full title
+- `body` — description / acceptance criteria
+- `labels` — label names
+- `state` — open/closed
+
+If the issue does not exist or the command fails, tell the user and stop.
+
+---
+
+## Step 2 — Derive branch name and slug
+
+Convert the title to a kebab-case slug:
+- Lowercase everything
+- Replace spaces and underscores with `-`
+- Strip all characters that are not alphanumeric or `-`
+- Collapse multiple consecutive `-` into one
+- Trim leading/trailing `-`
+- Truncate to 50 characters maximum
+
+Branch name: `issue/<number>-<slug>`
+Changelog filename: `issues/<number>-<slug>.md`
+
+---
+
+## Step 3 — Create the branch
+
+Check if the branch already exists:
+```
+git branch --list issue/<number>-<slug>
+```
+
+If it does NOT exist, create it from the current HEAD:
+```
+git checkout -b issue/<number>-<slug>
+```
+
+If it already exists, check it out:
+```
+git checkout issue/<number>-<slug>
+```
+
+Tell the user which branch is now active.
+
+---
+
+## Step 4 — Analyse the codebase
+
+Before writing the plan, read relevant parts of the codebase to understand the existing structure:
+- Look at `src/` to understand affected areas based on the issue title/body.
+- Read any files directly relevant to the issue.
+- Check recent git log for context: `git log --oneline -10`
+
+Use this to inform a concrete, realistic plan.
+
+---
+
+## Step 5 — Write the initial plan
+
+Think carefully about the issue. Consider:
+- What is the root cause or feature gap?
+- What files / layers need to change?
+- Are there multiple valid approaches? If so, list them with trade-offs.
+- Are there any open questions that require user input before proceeding?
+
+**If anything is ambiguous or if you see two or more equally valid approaches, STOP and ask the user for guidance before writing the changelog.**
+
+Once you are confident (or have received guidance), write the plan section. Be concrete — name files, types, methods where you know them. Do not be vague.
+
+---
+
+## Step 6 — Create the changelog file
+
+Create `issues/<number>-<slug>.md` in the solution root with the following content (fill in all placeholders):
+
+```markdown
+# Issue #<number> — <title>
+
+**GitHub:** https://github.com/jonatansoderberg/Maui.Spine/issues/<number>
+**Branch:** issue/<number>-<slug>
+**Status:** In Progress
+
+## Plan
+
+<your plan here — concrete steps, affected files, key decisions already made>
+
+## Open Questions
+
+<any questions that still need user input — leave empty if none>
+
+## Changes
+
+<!-- Updated as work progresses -->
+
+## Decisions
+
+<!-- Non-obvious choices and why -->
+```
+
+Do NOT commit this file yet. Just create it on disk.
+
+---
+
+## Step 7 — Report to the user
+
+Tell the user:
+- The branch that was created/checked out
+- The changelog file path
+- A concise summary of the plan
+- Any open questions you need answered before writing code
+
+Then wait for the user to confirm the plan or answer open questions before touching any source files.
+
+---
+
+## Important rules
+
+- **Do not write any C# or project code** until the user has approved the plan.
+- **Always keep the changelog updated** as work progresses — add to `Changes` and `Decisions` sections.
+- All C# must be modern (.NET latest, nullable reference types, file-scoped namespaces, primary constructors where appropriate).
+- Match existing code style and conventions — read the surrounding files before introducing new patterns.
+- If a decision point arises during implementation, update `Decisions` in the changelog and (if significant) pause to inform the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# Maui.Spine — Claude Instructions
+
+## Repository
+- **GitHub:** https://github.com/jonatansoderberg/Maui.Spine
+- **Solution file:** `Spine.slnx`
+- **Main source:** `src/`
+
+## Code Standards
+- All code must be modern C# / .NET (latest language features, nullable reference types enabled).
+- Match the style and conventions of the existing codebase before introducing new patterns.
+- No unnecessary abstractions — solve the problem at hand, not hypothetical future ones.
+- Write no comments unless the *why* is non-obvious (hidden constraint, subtle invariant, specific bug workaround).
+
+## GitHub Issue Workflow
+
+### Starting an issue
+Use the `/spine-issue <id>` skill to begin working on a GitHub issue. It will:
+1. Fetch issue details from GitHub.
+2. Create a branch named `issue/<id>-<slug>` (e.g. `issue/42-fix-crash-on-startup`).
+3. Create `issues/<id>-<slug>.md` as the living changelog for that issue.
+4. Write an initial plan section in that changelog — ask the user before proceeding if anything is ambiguous or if multiple approaches exist.
+
+### Branch naming
+```
+issue/<id>-<kebab-case-title>
+```
+Example: `issue/17-android-ripple-overflow`
+
+### Changelog file (`issues/<id>-<slug>.md`)
+Each issue gets its own file under `issues/` at the solution root. Structure:
+
+```markdown
+# Issue #<id> — <Title>
+
+**GitHub:** https://github.com/jonatansoderberg/Maui.Spine/issues/<id>
+**Branch:** issue/<id>-<slug>
+**Status:** In Progress | Completed | Abandoned
+
+## Plan
+<!-- Written before any code. Document approach, key decisions, open questions. -->
+
+## Changes
+<!-- Updated as work progresses. One bullet per meaningful change. -->
+
+## Decisions
+<!-- Any non-obvious choices made during implementation and why. -->
+```
+
+### Rules
+- Always reference the GitHub issue URL in the changelog.
+- Keep the changelog updated as you work — add to **Changes** and **Decisions** as you go.
+- If a decision requires user input, pause and ask before writing code.
+- On PR creation, link to the issue and reference the changelog.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at the solution root documenting project code standards and the GitHub issue workflow
- Adds `.claude/skills/spine-issue.md` — invoke `/spine-issue <id>` to start work on any GitHub issue; the skill fetches the issue, creates a branch (`issue/<id>-<slug>`), reads relevant source files, writes a plan to `issues/<id>-<slug>.md`, and waits for approval before touching any code
- Adds `issues/` directory where per-issue changelogs live (referenced by issue ID and title)
- Updates `.claude/settings.json` with permissions for the `gh` and `git` commands the skill needs

## How to use

```
/spine-issue 42
```

Claude will fetch issue #42, create `issue/42-<slug>` branch, document a plan in `issues/42-<slug>.md`, and ask before writing any C# code.

## Reviewer notes

No production code changed — this is purely tooling/workflow configuration for Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)