### PR TITLE
Fix SafeAreaEdges.None not respected on iOS and Mac Catalyst (#8)

### DIFF
--- a/issues/8-safe-area-edges-none-ios-maccatalyst.md
+++ b/issues/8-safe-area-edges-none-ios-maccatalyst.md
@@ -1,0 +1,42 @@
+# Issue #8 — SafeAreaEdges.None not respected on iOS/Mac Catalyst in sample app main page
+
+**GitHub:** https://github.com/jonatansoderberg/Maui.Spine/issues/8
+**Branch:** issue/8-safe-area-edges-none-ios-maccatalyst
+**Status:** Completed
+
+## Plan
+
+`NavigationRegion` (a `ContentView`) already has the full infrastructure for Spine-managed safe area: `ISystemInsetsProvider.SystemBarInsets` drives both `_frameActionView.Margin.Top` (header position) and `ApplySafeAreaPadding` (per-page content padding). Android works because `SystemInsetsProvider.Android.cs` reports real insets. On iOS and Mac Catalyst, `SystemInsetsProvider` always returned `Thickness.Zero`, so the header had no top margin and content had no padding — yet MAUI's own `ISafeAreaView2` geometry was still applied to `NavigationRegion` (a `ContentView` with default `SafeAreaEdges`), producing the visible gap.
+
+**Root cause:** `NavigationRegion` never opted out of MAUI's automatic safe-area geometry (`SafeAreaEdges.Default` → on iOS, applies system insets as a layout offset). `ISystemInsetsProvider` returned zero on iOS/Mac, so the negative-margin counteraction mechanism (which Android relies on) never fired.
+
+**Approach:**
+1. Set `NavigationRegion.SafeAreaEdges = Microsoft.Maui.SafeAreaEdges.None` — Spine owns the safe-area contract entirely; MAUI must not apply its own geometry.
+2. Remove the `_container.Margin = new Thickness(0, -insets.Top, 0, 0)` assignment from `UpdateContainerMargin` — with `SafeAreaEdges.None`, `NavigationRegion` content fills the full window, so a negative margin would overflow the window.
+3. Implement `SystemInsetsProvider` for `IOS || MACCATALYST` — reads `UIWindow.safeAreaInsets` (already in device-independent points), fires `InsetsChanged`.
+4. Wire up `UpdateFromUIWindow()` — call it from `HookIosPlatform` (iOS TFM) and `HookMacCatalystPlatform` (Mac Catalyst TFM) on `window.Activated` and on device orientation change.
+5. Revert `SpineHostPage.cs` to `this.SafeAreaEdges = Microsoft.Maui.SafeAreaEdges.None` (correct .NET 10 API).
+
+## Changes
+
+- Reverted `src/Plugin.Maui.Spine/Presentation/SpineHostPage.cs` — back to `this.SafeAreaEdges = Microsoft.Maui.SafeAreaEdges.None` (the broken `SetValue(UseSafeAreaProperty, false)` approach was a dead end).
+- Updated `src/Plugin.Maui.Spine/Presentation/NavigationRegion.cs`:
+  - Added `this.SafeAreaEdges = Microsoft.Maui.SafeAreaEdges.None` in constructor — disables MAUI's ISafeAreaView2 geometry on the content region.
+  - Removed `_container.Margin = new Thickness(0, -insets.Top, 0, 0)` from `UpdateContainerMargin` — no longer needed since the region fills the full window without MAUI offsetting it.
+- Updated `src/Plugin.Maui.Spine/Core/SystemInsetsProvider.cs` — adds `#if IOS || MACCATALYST` implementation: reads `UIWindow.safeAreaInsets` from the key window via `ConnectedScenes`, fires `InsetsChanged` when values change.
+- Updated `src/Plugin.Maui.Spine/Core/SpineApplication.cs` — re-added `partial void HookIosPlatform(Window window)` declaration and call in `CreateWindow`.
+- Created `src/Plugin.Maui.Spine/Platforms/iOS/SpineApplication.iOS.cs` — implements `HookIosPlatform`; calls `provider.UpdateFromUIWindow()` on `window.Activated` and on `UIDevice.OrientationDidChangeNotification`.
+- Updated `src/Plugin.Maui.Spine/Platforms/MacCatalyst/SpineApplication.MacCatalyst.cs` — added `provider.UpdateFromUIWindow()` call on `window.Activated` at the top of `HookMacCatalystPlatform`, before the tray-icon early return. After reading insets, applies `_host.Padding = new Thickness(0, -top, 0, 0)` to pull content behind the Mac Catalyst title bar (mirrors Windows approach).
+
+## Decisions
+
+- **Spine owns safe area, MAUI does not** — `NavigationRegion.SafeAreaEdges = None` is the authoritative statement: MAUI never applies geometry, Spine always applies it explicitly via `ISystemInsetsProvider` + `ApplySafeAreaPadding`. This mirrors how Android works and makes the platforms consistent.
+- **Removed negative-margin pattern** — the negative-margin trick (`-insets.Top` on `_container`) was the Android counteraction mechanism: MAUI offsets NavigationRegion's content by `insets.Top`, so the margin cancels it. With `SafeAreaEdges.None`, MAUI applies no offset, so no cancellation is needed. Keeping the negative margin would have pushed content above the window.
+- **No density conversion for UIKit insets** — `UIEdgeInsets` values are already in points (= DIPs on iOS/Mac). No division by screen density needed, unlike Android's pixel-based insets.
+- **`HookIosPlatform` is iOS TFM only, Mac Catalyst via `HookMacCatalystPlatform`** — `Platforms/iOS/` compiles for `net10.0-ios` only; Mac Catalyst uses `Platforms/MacCatalyst/`. Both call the same `UpdateFromUIWindow()` method defined under `#if IOS || MACCATALYST` in `SystemInsetsProvider.cs`.
+- **Mac Catalyst uses per-page negative `_container.Margin`, iOS uses it unconditionally** — on Mac Catalyst, `fullSizeContentView` makes `UIWindow` cover the title bar, and MAUI's own safe-area offset positions non-full-bleed pages correctly. Only full-bleed pages (`IsHeaderBarVisible=false`, `SafeAreaEdges=None`) apply the negative margin so their content extends behind the title bar. `SystemBarInsets` stays `Thickness.Zero` on Mac Catalyst to avoid double-offsetting `ApplySafeAreaPadding` on pages that use safe area.
+- **`NSWindowDidBecomeKeyNotification` used instead of `window.Activated`** — at `window.Activated` time, `UIWindowScene` is still a `_UIPlaceholderWindowScene` and doesn't expose the underlying `NSWindow`. The AppKit notification fires with the real `NSWindow` as its object.
+- **`NSWindowStyleMask.FullSizeContentView` (bit 32768) + `setTitlebarAppearsTransparent:`** — these two NSWindow properties are set via P/Invoke to extend UIKit content behind the native title bar. After setting them, `UIView.SetNeedsLayout + LayoutIfNeeded` forces UIKit to update `safeAreaInsets.top` to the title bar height before it is read.
+- **`MacTitleBarHeight` on `SystemInsetsProvider`** — Mac Catalyst-specific field separate from `SystemBarInsets`. `SetMacTitleBarHeight` fires `InsetsChanged` so `NavigationRegion.UpdateContainerMargin` re-runs. `NavigationRegion` casts `_insetsProvider` to `SystemInsetsProvider` under `#if MACCATALYST` to read this value.
+- **`UpdateContainerMargin` called on `CurrentRegionViewModel` change** — the per-page condition (`IsHeaderBarVisible`, `SafeAreaEdges`) must be re-evaluated on navigation, not only when insets change.
+- **`window.Activated` as the trigger** — the safe area is finalised by the time the window is first activated. Subsequent activations are no-ops unless insets changed (guarded by the equality check in `UpdateFromUIWindow`). Orientation changes are handled via `UIDevice.OrientationDidChangeNotification` on iOS.

--- a/src/Plugin.Maui.Spine/Core/SpineApplication.cs
+++ b/src/Plugin.Maui.Spine/Core/SpineApplication.cs
@@ -50,6 +50,7 @@ public partial class SpineApplication<TNavigable> : Application where TNavigable
         // system bar insets are measured and available to ViewModels.
         HookWindowsPlatform(window);
         HookAndroidPlatform(window);
+        HookIosPlatform(window);
         HookMacCatalystPlatform(window);
 
         _navigationService.SetRootAsync<TNavigable>().SafeFireAndForget();
@@ -60,6 +61,7 @@ public partial class SpineApplication<TNavigable> : Application where TNavigable
             partial void InitializeWindowsTitleBar(Window window);
             partial void HookWindowsPlatform(Window window);
             partial void HookAndroidPlatform(Window window);
+            partial void HookIosPlatform(Window window);
             partial void HookMacCatalystPlatform(Window window);
 
             /// <summary>Closes the window. On Windows, if CloseToBackground is enabled the window hides to tray instead.</summary>

--- a/src/Plugin.Maui.Spine/Core/SystemInsetsProvider.cs
+++ b/src/Plugin.Maui.Spine/Core/SystemInsetsProvider.cs
@@ -1,19 +1,104 @@
 #if !ANDROID
 
+#if IOS || MACCATALYST
+using UIKit;
+#endif
+
 namespace Plugin.Maui.Spine.Core;
 
 /// <summary>
 /// Default <see cref="ISystemInsetsProvider"/> for platforms that do not require
-/// manual system bar inset management (iOS, macOS, Windows).
-/// Always returns <see cref="Thickness.Zero"/>.
+/// manual system bar inset management (Windows, macOS).
+/// iOS and Mac Catalyst report real <c>UIWindow.safeAreaInsets</c> so that
+/// <see cref="Presentation.NavigationRegion"/> can apply them explicitly instead
+/// of relying on MAUI's automatic ISafeAreaView2 geometry.
 /// </summary>
 internal sealed class SystemInsetsProvider : ISystemInsetsProvider
 {
+#if IOS
+    private Thickness _systemBarInsets;
+
+    /// <inheritdoc/>
+    public Thickness SystemBarInsets => _systemBarInsets;
+
+    /// <inheritdoc/>
+    public event Action? InsetsChanged;
+
+    /// <summary>
+    /// Reads the current safe-area insets from the given <paramref name="uiWindow"/> and fires
+    /// <see cref="InsetsChanged"/> if the values have changed.
+    /// UIKit points are already device-independent units — no density conversion needed.
+    /// </summary>
+    internal void UpdateFromUIWindow(UIWindow uiWindow)
+    {
+        var si = uiWindow.SafeAreaInsets;
+        var newInsets = new Thickness(
+            (double)si.Left,
+            (double)si.Top,
+            (double)si.Right,
+            (double)si.Bottom);
+
+        if (newInsets == _systemBarInsets) return;
+        _systemBarInsets = newInsets;
+        InsetsChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Reads insets from the key UIWindow discovered via <c>ConnectedScenes</c>.
+    /// Used by the iOS hook where the MAUI handler's platform view may not be available.
+    /// </summary>
+    internal void UpdateFromUIWindow()
+    {
+        var window = UIApplication.SharedApplication.ConnectedScenes
+            .OfType<UIWindowScene>()
+            .SelectMany(s => s.Windows)
+            .FirstOrDefault(w => w.IsKeyWindow)
+            ?? UIApplication.SharedApplication.ConnectedScenes
+                .OfType<UIWindowScene>()
+                .SelectMany(s => s.Windows)
+                .FirstOrDefault();
+
+        if (window is null) return;
+        UpdateFromUIWindow(window);
+    }
+#elif MACCATALYST
+    // SystemBarInsets stays zero on Mac Catalyst. After fullSizeContentView is enabled,
+    // MAUI's own safeAreaInsets mechanism pushes NavigationRegion down by the title bar
+    // height. NavigationRegion counteracts that via a per-page negative container margin
+    // (full-bleed pages only), using MacTitleBarHeight below rather than SystemBarInsets,
+    // so that ApplySafeAreaPadding on non-full-bleed pages is unaffected.
+    public Thickness SystemBarInsets => Thickness.Zero;
+
+    public event Action? InsetsChanged;
+
+    private double _macTitleBarHeight;
+
+    internal double MacTitleBarHeight => _macTitleBarHeight;
+
+    /// <summary>
+    /// Stores the measured native title-bar height and fires <see cref="InsetsChanged"/>
+    /// so <see cref="Presentation.NavigationRegion"/> can update its container margin.
+    /// </summary>
+    internal void SetMacTitleBarHeight(double height)
+    {
+        if (Math.Abs(_macTitleBarHeight - height) < 0.5) return;
+        _macTitleBarHeight = height;
+        InsetsChanged?.Invoke();
+    }
+
+    internal void UpdateFromUIWindow(UIWindow uiWindow)
+    {
+        var top = (double)uiWindow.SafeAreaInsets.Top;
+        if (top == 0) top = 28; // standard Mac title bar fallback
+        SetMacTitleBarHeight(top);
+    }
+#else
     /// <inheritdoc/>
     public Thickness SystemBarInsets => Thickness.Zero;
 
     /// <inheritdoc/>
     public event Action? InsetsChanged { add { } remove { } }
+#endif
 }
 
 #endif

--- a/src/Plugin.Maui.Spine/Platforms/MacCatalyst/SpineApplication.MacCatalyst.cs
+++ b/src/Plugin.Maui.Spine/Platforms/MacCatalyst/SpineApplication.MacCatalyst.cs
@@ -20,6 +20,41 @@ public partial class SpineApplication<TNavigable> where TNavigable : INavigable
 
     partial void HookMacCatalystPlatform(Window window)
     {
+        // Enable fullSizeContentView so UIWindow covers the full NSWindow frame (including
+        // the native title bar), then read safeAreaInsets.top as the title bar height.
+        // NavigationRegion uses that height to apply a per-page negative container margin
+        // only for full-bleed pages (IsHeaderBarVisible=false, SafeAreaEdges=None).
+        var provider = _services.GetRequiredService<ISystemInsetsProvider>() as SystemInsetsProvider;
+        if (provider is not null)
+        {
+            // window.Activated fires while UIWindowScene is still a _UIPlaceholderWindowScene,
+            // which doesn't expose the underlying NSWindow. Instead, observe the AppKit
+            // NSWindowDidBecomeKeyNotification — its object IS the real NSWindow.
+            NSNotificationCenter.DefaultCenter.AddObserver(
+                new NSString("NSWindowDidBecomeKeyNotification"),
+                notification => MainThread.BeginInvokeOnMainThread(() =>
+                {
+                    if (notification.Object is not { } nsObj) return;
+                    if (AppKitObjC.IsStatusBarWindow(nsObj.Handle)) return;
+
+                    EnableFullSizeContentView(nsObj.Handle);
+
+                    if (window.Handler?.PlatformView is not UIKit.UIWindow uiWindow) return;
+
+                    // Force a UIKit layout pass so safeAreaInsets update for the new
+                    // fullSizeContentView geometry before we read them.
+                    uiWindow.SetNeedsLayout();
+                    uiWindow.LayoutIfNeeded();
+
+                    // Read title-bar height now that UIKit has updated safeAreaInsets.
+                    // NavigationRegion applies a per-page negative container margin for
+                    // full-bleed pages (IsHeaderBarVisible=false, SafeAreaEdges=None);
+                    // non-full-bleed pages rely on MAUI's own safe-area offset instead.
+                    provider.UpdateFromUIWindow(uiWindow);
+                }),
+                null);
+        }
+
         var options = _services.GetRequiredService<SpineOptions>();
         var macOptions = options.MacOS;
 
@@ -40,6 +75,22 @@ public partial class SpineApplication<TNavigable> where TNavigable : INavigable
 
         if (macOptions.CloseToBackground)
             SetupCloseToBackground(window);
+    }
+
+    private static void EnableFullSizeContentView(IntPtr nsWindowPtr)
+    {
+        try
+        {
+            // NSWindowStyleMask.FullSizeContentView = 1 << 15 — extends the content view to
+            // fill the full NSWindow frame including the area behind the title bar.
+            var mask = AppKitObjC.nuint_msgSend(nsWindowPtr, Selector.GetHandle("styleMask"));
+            AppKitObjC.Void_msgSend_nuint(nsWindowPtr, Selector.GetHandle("setStyleMask:"), mask | 32768u);
+            AppKitObjC.Void_msgSend_bool(nsWindowPtr, Selector.GetHandle("setTitlebarAppearsTransparent:"), true);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[Spine/Mac] EnableFullSizeContentView: {ex.GetType().Name}: {ex.Message}");
+        }
     }
 
     private void SetupMenuBarIcon(SpineOptions.MacOSPlatformOptions macOptions, SpineOptions options)
@@ -245,6 +296,12 @@ internal static class AppKitObjC
 
     [DllImport(Lib, EntryPoint = "objc_msgSend")]
     public static extern void Void_msgSend_bool(IntPtr receiver, IntPtr selector, bool arg1);
+
+    [DllImport(Lib, EntryPoint = "objc_msgSend")]
+    public static extern nuint nuint_msgSend(IntPtr receiver, IntPtr selector);
+
+    [DllImport(Lib, EntryPoint = "objc_msgSend")]
+    public static extern void Void_msgSend_nuint(IntPtr receiver, IntPtr selector, nuint arg1);
 
     public static bool IsStatusBarWindow(IntPtr win)
     {

--- a/src/Plugin.Maui.Spine/Platforms/iOS/SpineApplication.iOS.cs
+++ b/src/Plugin.Maui.Spine/Platforms/iOS/SpineApplication.iOS.cs
@@ -1,0 +1,22 @@
+using Foundation;
+using Plugin.Maui.Spine.Presentation;
+using UIKit;
+
+namespace Plugin.Maui.Spine.Core;
+
+public partial class SpineApplication<TNavigable> where TNavigable : INavigable
+{
+    partial void HookIosPlatform(Window window)
+    {
+        var provider = _services.GetRequiredService<ISystemInsetsProvider>() as SystemInsetsProvider;
+        if (provider is null) return;
+
+        // Read insets once the window is active (safe area is finalised by then).
+        window.Activated += (_, _) => provider.UpdateFromUIWindow();
+
+        // Re-read on device rotation — safe area changes with orientation.
+        NSNotificationCenter.DefaultCenter.AddObserver(
+            UIDevice.OrientationDidChangeNotification,
+            _ => MainThread.BeginInvokeOnMainThread(provider.UpdateFromUIWindow));
+    }
+}

--- a/src/Plugin.Maui.Spine/Presentation/NavigationRegion.cs
+++ b/src/Plugin.Maui.Spine/Presentation/NavigationRegion.cs
@@ -57,6 +57,12 @@ public sealed class NavigationRegion : ContentView
         viewModel.Presentation = presentation;
         BindingContext = viewModel;
 
+        // Disable MAUI's automatic ISafeAreaView2 geometry on this ContentView.
+        // Spine owns the safe-area contract: ISystemInsetsProvider supplies the real
+        // platform insets, UpdateContainerMargin positions the header, and
+        // ApplySafeAreaPadding pads each content host per the page's SafeAreaEdges.
+        this.SafeAreaEdges = Microsoft.Maui.SafeAreaEdges.None;
+
         viewModel.PropertyChanged += OnViewModelPropertyChanged;
 
         _container = new Grid();
@@ -118,7 +124,33 @@ public sealed class NavigationRegion : ContentView
     private void UpdateContainerMargin()
     {
         var insets = _insetsProvider.SystemBarInsets;
-        _container.Margin = new Thickness(0, -insets.Top, 0, 0);
+
+#if IOS
+        // ContentPage's safe area cannot be disabled on iOS — MAUI always offsets the page
+        // content by UIView.safeAreaInsets regardless of SafeAreaEdges = None on the host page.
+        // Counteract that offset with a negative margin so _container fills the full window,
+        // allowing Spine to apply insets explicitly via ApplySafeAreaPadding.
+        _container.Margin = new Thickness(-insets.Left, -insets.Top, -insets.Right, -insets.Bottom);
+#endif
+
+#if MACCATALYST
+        // After fullSizeContentView, MAUI's safeAreaInsets offset already positions
+        // NavigationRegion below the title bar for normal pages. Only full-bleed pages
+        // (no header bar, no safe area) need the negative counteraction so their content
+        // extends behind the title bar. SystemBarInsets stays zero on Mac Catalyst so
+        // ApplySafeAreaPadding on other pages is unaffected.
+        {
+            var vm = ViewModel.CurrentRegionViewModel;
+            var titleBarH = (_insetsProvider as SystemInsetsProvider)?.MacTitleBarHeight ?? 0;
+            bool fullBleed = titleBarH > 0
+                && vm is not null
+                && !vm.IsHeaderBarVisible
+                && vm.SafeAreaEdges == SpineSafeArea.None;
+            _container.Margin = fullBleed
+                ? new Thickness(0, -titleBarH, 0, 0)
+                : Thickness.Zero;
+        }
+#endif
 
         var topMargin = insets.Top;
         if (ViewModel.Presentation is NavigationPresentation.Sheet)
@@ -180,6 +212,10 @@ public sealed class NavigationRegion : ContentView
     {
         if (e.PropertyName == nameof(ViewModel.CurrentRegionViewModel))
         {
+            // Mac Catalyst: container margin depends on the new page's SafeAreaEdges +
+            // IsHeaderBarVisible, so recalculate whenever the page changes.
+            UpdateContainerMargin();
+
             _frameActionView?.SetBinding(HeaderBar.IsHeaderBarVisibleProperty, new Binding("IsHeaderBarVisible", source: ViewModel.CurrentRegionViewModel));
             _frameActionView?.SetBinding(HeaderBar.IsBackButtonVisibleProperty, new Binding("IsBackButtonVisible", source: ViewModel.CurrentRegionViewModel));
             _frameActionView?.SetBinding(HeaderBar.IsTitleBarVisibleProperty, new Binding("IsTitleBarVisible", source: ViewModel.CurrentRegionViewModel));

--- a/src/Plugin.Maui.Spine/Presentation/SpineHostPage.cs
+++ b/src/Plugin.Maui.Spine/Presentation/SpineHostPage.cs
@@ -48,8 +48,10 @@ public partial class SpineHostPage : ContentPage, IDisposable
         NavigationRegion rootFrameView,
         [FromKeyedServices("BottomSheet")] NavigationRegion bottomSheetFrameView)
     {
-        // Edge-to-edge: Spine manages safe-area padding per-page on the NavigationRegion
-        // content hosts, so the host page must not apply any system-bar padding itself.
+        // Spine manages safe-area padding per-page on the NavigationRegion content hosts.
+        // The host page must not apply any inset itself — NavigationRegion.SafeAreaEdges = None
+        // (set in NavigationRegion's constructor) also disables MAUI's automatic ISafeAreaView2
+        // geometry, and ISystemInsetsProvider reports the real insets Spine applies explicitly.
         this.SafeAreaEdges = Microsoft.Maui.SafeAreaEdges.None;
 
         SheetNavigationRegion = bottomSheetFrameView;


### PR DESCRIPTION
## Summary

Fixes #8 — full-bleed layouts (e.g. a CollectionView header image that should extend flush to the window top) were not working on iOS or Mac Catalyst because `SafeAreaEdges = None` cannot fully disable MAUI's automatic safe-area geometry on ContentPage.

- **iOS**: implement `ISystemInsetsProvider` for iOS using `UIWindow.safeAreaInsets`. `NavigationRegion` applies a negative `_container.Margin` to counteract MAUI's unavoidable `safeAreaInsets` layout offset, then Spine applies insets explicitly per page via `ApplySafeAreaPadding`.

- **Mac Catalyst**: enable `NSWindowStyleMask.FullSizeContentView` + `setTitlebarAppearsTransparent` via AppKit P/Invoke (accessed through `NSWindowDidBecomeKeyNotification`, since `UIWindowScene` is a placeholder at `window.Activated` time). `NavigationRegion` applies a negative container margin **only for full-bleed pages** (`IsHeaderBarVisible=false` + `SafeAreaEdges=None`). Non-full-bleed pages rely on MAUI's own safe-area offset and are unaffected. `SystemBarInsets` stays `Thickness.Zero` on Mac Catalyst to avoid double-offsetting `ApplySafeAreaPadding` on pages that use safe area.

## Key decisions

- `NavigationRegion.SafeAreaEdges = None` disables MAUI's automatic `ISafeAreaView2` geometry on the `ContentView` itself; the negative margin counteracts what MAUI still applies at the `ContentPage` level.
- Mac Catalyst title-bar height is read dynamically from `UIWindow.safeAreaInsets.top` after `fullSizeContentView` + a forced `LayoutIfNeeded` pass; falls back to 28 pt if still zero.
- `UpdateContainerMargin` is now also called on `CurrentRegionViewModel` changes so the per-page full-bleed condition re-evaluates on navigation.

## Test plan

- [ ] iOS: header image on main page extends flush to status bar / Dynamic Island top edge
- [ ] iOS: pages with `SafeAreaEdges` set still receive correct inset padding
- [ ] Mac Catalyst: header image on main page extends behind the native title bar (title bar is transparent, traffic lights visible over image)
- [ ] Mac Catalyst: pages with a header bar start content correctly below the title bar, not double-offset
- [ ] Mac Catalyst: tray icon (if configured) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)